### PR TITLE
Feature: SMT Updates for vouch and score implementation

### DIFF
--- a/go_sequencer/common/errors.go
+++ b/go_sequencer/common/errors.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"errors"
-
-	"github.com/hermeznetwork/tracerr"
 )
 
 // ErrNotInFF is used when the *big.Int does not fit inside the Finite Field
@@ -18,6 +16,9 @@ var ErrIdxOverflow = errors.New("Idx overflow, max value: 2**48 -1")
 // ErrBatchQueueEmpty is used when the coordinator.BatchQueue.Pop() is called and has no elements
 var ErrBatchQueueEmpty = errors.New("BatchQueue empty")
 
+// ErrScoreOverflow is used when a given score overflows the maximum capacity of the uint32 4,294,967,295
+var ErrScoreOverflow = errors.New("Score overflow, max value uint32 - 4,294,967,295")
+
 // ErrTODO is used when a function is not yet implemented
 var ErrTODO = errors.New("TODO")
 
@@ -26,5 +27,5 @@ var ErrDone = errors.New("done")
 
 // IsErrDone returns true if the error or wrapped (with tracerr) error is ErrDone
 func IsErrDone(err error) bool {
-	return tracerr.Unwrap(err) == ErrDone
+	return Unwrap(err) == ErrDone
 }

--- a/go_sequencer/common/score.go
+++ b/go_sequencer/common/score.go
@@ -1,10 +1,45 @@
 package common
 
+import (
+	"encoding/binary"
+	"math/big"
+)
+
 // Score is a struct that gives an information about score
 // of each accounts.
 type Score struct {
 	Idx      AccountIdx `meddler:"idx"`
 	BatchNum BatchNum   `meddler:"batch_num"`
-	Nonce    Nonce      `meddler:"-"` // max of 40 bits used
-	Score    bool       `meddler:"score"`
+	Score    ScoreType  `meddler:"score"` //30bits
+}
+
+type ScoreType uint32
+
+// MaxScoreValue represents the maximum value for ScoreType.
+const MaxScoreValue = ^ScoreType(0)
+
+// Bytes converts the ScoreType to a [4]byte array.
+func (s ScoreType) Bytes() ([4]byte, error) {
+	if s > MaxScoreValue {
+		return [4]byte{}, ErrScoreOverflow
+	}
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], uint32(s))
+	return b, nil
+}
+
+// FromBytes returns Score from a [4]byte
+func GetScoreFromBytes(b [4]byte) *Score {
+	var scoreBytes [4]byte
+	copy(scoreBytes[:], b[:])
+	score := binary.BigEndian.Uint32(scoreBytes[:])
+	s := Score{Score: ScoreType(score)}
+	return &s
+}
+
+// BigIntFromBool returns bool from *big.Int
+func (s ScoreType) BigIntFromScore() *big.Int {
+	bigInt := new(big.Int)
+	bigInt.SetUint64(uint64(s))
+	return bigInt
 }

--- a/go_sequencer/common/vouch.go
+++ b/go_sequencer/common/vouch.go
@@ -15,7 +15,7 @@ type Vouch struct {
 	Value    bool     `meddler:"value"`
 }
 
-type VouchIdx uint64
+type VouchIdx uint64 //TODO: vouch Idx would be big.Int change this and other functionalities based on that
 
 const (
 	// NLeafElems is the number of elements for a leaf in vouch tree

--- a/go_sequencer/database/statedb/account_service.go
+++ b/go_sequencer/database/statedb/account_service.go
@@ -11,7 +11,7 @@ import (
 var (
 	// ErrAccountAlreadyExists is used when CreateAccount is called and the
 	// Account already exists
-	ErrAccountAlreadyExists = errors.New("Can not CreateAccount because Account already exists")
+	ErrAccountAlreadyExists = errors.New("can not CreateAccount because Account already exists")
 	// PrefixKeyAccIdx is the key prefix for accountIdx in the db
 	PrefixKeyAccIdx = []byte("i:")
 	// PrefixKeyAccHash is the key prefix for account hash in the db

--- a/go_sequencer/database/statedb/merkel_tree.go
+++ b/go_sequencer/database/statedb/merkel_tree.go
@@ -9,6 +9,7 @@ type enum string
 const (
 	Account enum = "Account"
 	Vouch   enum = "Vouch"
+	Score   enum = "Score"
 )
 
 type TreeNodeHash interface {

--- a/go_sequencer/database/statedb/merkel_tree.go
+++ b/go_sequencer/database/statedb/merkel_tree.go
@@ -8,7 +8,7 @@ type enum string
 
 const (
 	Account enum = "Account"
-	Link    enum = "Link"
+	Vouch   enum = "Vouch"
 )
 
 type TreeNodeHash interface {
@@ -19,13 +19,12 @@ func BigInt(idx int) *big.Int {
 	return big.NewInt(int64(idx))
 }
 
-// GetMTRoot returns the root of the Merkle Tree
-func (s *StateDB) GetMTRoot(treeType enum) *big.Int {
-	var root *big.Int
-	if treeType == Account {
-		root = s.AccountTree.Root().BigInt()
-	} else {
-		root = s.VouchTree.Root().BigInt()
-	}
-	return root
+// GetMTRoot returns the root of the Merkle Tree Account
+func (s *StateDB) GetMTRootAccount(treeType enum) *big.Int {
+	return s.AccountTree.Root().BigInt()
+}
+
+// GetMTRoot returns the root of the Merkle Tree Vouch
+func (s *StateDB) GetMTRootVouch(treeType enum) *big.Int {
+	return s.VouchTree.Root().BigInt()
 }

--- a/go_sequencer/database/statedb/score_service.go
+++ b/go_sequencer/database/statedb/score_service.go
@@ -1,0 +1,151 @@
+package statedb
+
+import (
+	"errors"
+	"tokamak-sybil-resistance/common"
+
+	"github.com/iden3/go-merkletree"
+	"github.com/iden3/go-merkletree/db"
+)
+
+var (
+	ErrAlreadyScored = errors.New("cannot add score as already added")
+	// PrefixKeyScoreIdx is the key prefix for scoreIdx in the db
+	PrefixKeyScoreIdx = []byte("s:")
+)
+
+// CreateScore creates a new Score in the StateDB for the given Idx.
+// Idx would be account idx for which the score is.
+// If StateDB.MT==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) CreateScore(idx common.AccountIdx, score *common.Score) (
+	*merkletree.CircomProcessorProof, error) {
+	cpp, err := AddScoreInTreeDB(s.db.DB(), s.ScoreTree, idx, score)
+	if err != nil {
+		return cpp, common.Wrap(err)
+	}
+	return cpp, nil
+}
+
+// AddScoreInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree. Creates a new Score in the StateDB for the given Idx. If
+// StateDB.MT==nil, MerkleTree is no affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof
+func AddScoreInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.AccountIdx,
+	score *common.Score) (*merkletree.CircomProcessorProof, error) {
+	// store at the DB the key: idx, and value: leaf value
+	tx, err := sto.NewTx()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	scoreBytes, err := score.Score.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	_, err = tx.Get(append(PrefixKeyScoreIdx, idxBytes[:]...))
+	if err != db.ErrNotFound {
+		return nil, common.Wrap(ErrAlreadyScored)
+	}
+
+	err = tx.Put(append(PrefixKeyScoreIdx, idxBytes[:]...), scoreBytes[:])
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if mt != nil {
+		return mt.AddAndGetCircomProof(idx.BigInt(), score.Score.BigIntFromScore())
+	}
+
+	return nil, nil
+}
+
+// MTGetScoreProof returns the CircomVerifierProof for a given accountIdx
+func (s *StateDB) MTGetScoreProof(idx common.AccountIdx) (*merkletree.CircomVerifierProof, error) {
+	if s.ScoreTree == nil {
+		return nil, common.Wrap(ErrStateDBWithoutMT)
+	}
+	p, err := s.ScoreTree.GenerateSCVerifierProof(idx.BigInt(), s.ScoreTree.Root())
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	return p, nil
+}
+
+// GetScore returns the score for the given Idx
+func (s *StateDB) GetScore(idx common.AccountIdx) (*common.Score, error) {
+	return GetScoreInTreeDB(s.db.DB(), idx)
+}
+
+// GetScoreInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  Returns the score for the given Idx
+func GetScoreInTreeDB(sto db.Storage, idx common.AccountIdx) (*common.Score, error) {
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	scoreBytes, err := sto.Get(append(PrefixKeyScoreIdx, idxBytes[:]...))
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	var b [4]byte
+	copy(b[:], scoreBytes)
+	score := common.GetScoreFromBytes(b)
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	return score, nil
+}
+
+// UpdateScore updates the Score in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) UpdateScore(idx common.AccountIdx, score *common.Score) (
+	*merkletree.CircomProcessorProof, error) {
+	return UpdateScoreInTreeDB(s.db.DB(), s.ScoreTree, idx, score)
+}
+
+// UpdateScoreInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  Updates the Score in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func UpdateScoreInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.AccountIdx,
+	score *common.Score) (*merkletree.CircomProcessorProof, error) {
+	// store at the DB the key: idx and value: leaf value
+	tx, err := sto.NewTx()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	scoreBytes, err := score.Score.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	err = tx.Put(append(PrefixKeyAccIdx, idxBytes[:]...), scoreBytes[:])
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if mt != nil {
+		proof, err := mt.Update(idx.BigInt(), score.Score.BigIntFromScore())
+		return proof, common.Wrap(err)
+	}
+	return nil, nil
+}

--- a/go_sequencer/database/statedb/state_db.go
+++ b/go_sequencer/database/statedb/state_db.go
@@ -105,11 +105,11 @@ func NewStateDB(cfg Config) (*StateDB, error) {
 	}
 
 	mtAccount, _ := merkletree.NewMerkleTree(kv.StorageWithPrefix(PrefixKeyMT), 14)
-	mtLink, _ := merkletree.NewMerkleTree(kv.StorageWithPrefix(PrefixKeyMT), 14)
+	mtVouch, _ := merkletree.NewMerkleTree(kv.StorageWithPrefix(PrefixKeyMT), 14)
 	return &StateDB{
 		db:          kv,
 		AccountTree: mtAccount,
-		VouchTree:   mtLink,
+		VouchTree:   mtVouch,
 	}, nil
 }
 

--- a/go_sequencer/database/statedb/vouch_service.go
+++ b/go_sequencer/database/statedb/vouch_service.go
@@ -2,6 +2,7 @@ package statedb
 
 import (
 	"errors"
+	"math/big"
 	"tokamak-sybil-resistance/common"
 
 	"github.com/iden3/go-merkletree"
@@ -139,6 +140,19 @@ func UpdateVouchInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.V
 		return proof, common.Wrap(err)
 	}
 	return nil, nil
+}
+
+// GenerateVouchIdx
+func GenerateVouchIdx(vouchFrom common.AccountIdx, vouchTo common.AccountIdx) *big.Int {
+	// Create a new big.Int to hold the result
+	result := new(big.Int)
+
+	// Shift vouchFrom left by 64 bits and add vouchTo
+	result.SetUint64(uint64(vouchFrom))
+	result.Lsh(result, 64)
+	result.Or(result, new(big.Int).SetUint64(uint64(vouchTo)))
+
+	return result
 }
 
 // func BytesLink(l *models.Link) [5]byte {


### PR DESCRIPTION
This PR contains - 

- Some updates, restructuring related to vouches.
- Implementation of Score SMT 

**Note** - For type `VouchIdx` I think we'll need to update that to big.Int since it'll be 2*Nlevel of AccountIdx. For that i've added an TODO comment, Will update the same either in this PR or in seperate PR. 