### PR TITLE
restore statedb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ proof.json
 public.json
 *.wtns
 
-#stateDB
-stateDB
-
 #.env
 .env
 

--- a/sequencer/database/statedb/account_service.go
+++ b/sequencer/database/statedb/account_service.go
@@ -1,0 +1,353 @@
+package statedb
+
+import (
+	"errors"
+	"math/big"
+	"tokamak-sybil-resistance/common"
+
+	"github.com/iden3/go-merkletree"
+	"github.com/iden3/go-merkletree/db"
+)
+
+var (
+	// ErrAccountAlreadyExists is used when CreateAccount is called and the
+	// Account already exists
+	ErrAccountAlreadyExists = errors.New("cannot CreateAccount because Account already exists")
+	// PrefixKeyAccIdx is the key prefix for accountIdx in the db
+	PrefixKeyAccIdx = []byte("i:")
+	// PrefixKeyAccHash is the key prefix for account hash in the db
+	PrefixKeyAccHash = []byte("h:")
+	// PrefixKeyAddr is the key prefix for address in the db
+	PrefixKeyAddr = []byte("a:")
+	// PrefixKeyAddrBJJ is the key prefix for address-babyjubjub in the db
+	PrefixKeyAddrBJJ = []byte("ab:")
+)
+
+// CreateAccount creates a new Account in the StateDB for the given Idx.  If
+// StateDB.MT==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) CreateAccount(idx common.AccountIdx, account *common.Account) (
+	*merkletree.CircomProcessorProof, error) {
+	cpp, err := CreateAccountInTreeDB(s.db.DB(), s.AccountTree, idx, account)
+	if err != nil {
+		return cpp, common.Wrap(err)
+	}
+	// store idx by EthAddr & BJJ
+	err = s.setIdxByEthAddrBJJ(idx, account.EthAddr, account.BJJ)
+	return cpp, common.Wrap(err)
+}
+
+// CreateAccountInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  Creates a new Account in the StateDB for the given Idx.  If
+// StateDB.MT==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func CreateAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.AccountIdx,
+	account *common.Account) (*merkletree.CircomProcessorProof, error) {
+	// store at the DB the key: v, and value: leaf.Bytes()
+	v, err := account.HashValue()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	accountBytes, err := account.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	// store the Leaf value
+	tx, err := sto.NewTx()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	_, err = tx.Get(append(PrefixKeyAccIdx, idxBytes[:]...))
+	if common.Unwrap(err) != db.ErrNotFound {
+		return nil, common.Wrap(ErrAccountAlreadyExists)
+	}
+
+	err = tx.Put(append(PrefixKeyAccHash, v.Bytes()...), accountBytes[:])
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	err = tx.Put(append(PrefixKeyAccIdx, idxBytes[:]...), v.Bytes())
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if mt != nil {
+		return mt.AddAndGetCircomProof(idx.BigInt(), v)
+	}
+
+	return nil, nil
+}
+
+// MTGetAccountProof returns the CircomVerifierProof for a given accountIdx
+func (s *StateDB) MTGetAccountProof(idx common.AccountIdx) (*merkletree.CircomVerifierProof, error) {
+	if s.AccountTree == nil {
+		return nil, common.Wrap(ErrStateDBWithoutMT)
+	}
+	p, err := s.AccountTree.GenerateSCVerifierProof(idx.BigInt(), s.AccountTree.Root())
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	return p, nil
+}
+
+// GetAccount returns the account for the given Idx
+func (s *StateDB) GetAccount(idx common.AccountIdx) (*common.Account, error) {
+	return GetAccountInTreeDB(s.db.DB(), idx)
+}
+
+func accountsIter(db db.Storage, fn func(a *common.Account) (bool, error)) error {
+	idxDB := db.WithPrefix(PrefixKeyAccIdx)
+	if err := idxDB.Iterate(func(k []byte, v []byte) (bool, error) {
+		idx, err := common.IdxFromBytes(k)
+		if err != nil {
+			return false, common.Wrap(err)
+		}
+		acc, err := GetAccountInTreeDB(db, idx)
+		if err != nil {
+			return false, common.Wrap(err)
+		}
+		ok, err := fn(acc)
+		if err != nil {
+			return false, common.Wrap(err)
+		}
+		return ok, nil
+	}); err != nil {
+		return common.Wrap(err)
+	}
+	return nil
+}
+
+func getAccounts(db db.Storage) ([]common.Account, error) {
+	accs := []common.Account{}
+	if err := accountsIter(
+		db,
+		func(a *common.Account) (bool, error) {
+			accs = append(accs, *a)
+			return true, nil
+		},
+	); err != nil {
+		return nil, common.Wrap(err)
+	}
+	return accs, nil
+}
+
+// TestGetAccounts returns all the accounts in the db.  Use only in tests.
+// Outside tests getting all the accounts is discouraged because it's an
+// expensive operation, but if you must do it, use `LastRead()` method to get a
+// thread-safe and consistent view of the stateDB.
+func (s *StateDB) TestGetAccounts() ([]common.Account, error) {
+	return getAccounts(s.db.DB())
+}
+
+// GetAccountInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  GetAccount returns the account for the given Idx
+func GetAccountInTreeDB(sto db.Storage, idx common.AccountIdx) (*common.Account, error) {
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	vBytes, err := sto.Get(append(PrefixKeyAccIdx, idxBytes[:]...))
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	accBytes, err := sto.Get(append(PrefixKeyAccHash, vBytes...))
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	var b [32 * common.NAccountLeafElems]byte
+	copy(b[:], accBytes)
+	account, err := common.AccountFromBytes(b)
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	account.Idx = idx
+	return account, nil
+}
+
+// UpdateAccount updates the Account in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) UpdateAccount(idx common.AccountIdx, account *common.Account) (
+	*merkletree.CircomProcessorProof, error) {
+	return UpdateAccountInTreeDB(s.db.DB(), s.AccountTree, idx, account)
+}
+
+// UpdateAccountInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  Updates the Account in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func UpdateAccountInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.AccountIdx,
+	account *common.Account) (*merkletree.CircomProcessorProof, error) {
+	// store at the DB the key: v, and value: account.Bytes()
+	v, err := account.HashValue()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	accountBytes, err := account.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	tx, err := sto.NewTx()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	err = tx.Put(append(PrefixKeyAccHash, v.Bytes()...), accountBytes[:])
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	err = tx.Put(append(PrefixKeyAccIdx, idxBytes[:]...), v.Bytes())
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	if mt != nil {
+		proof, err := mt.Update(idx.BigInt(), v)
+		return proof, common.Wrap(err)
+	}
+	return nil, nil
+}
+
+// CurrentIdx returns the current in-memory CurrentIdx of the StateDB.db
+func (s *StateDB) CurrentAccountIdx() common.AccountIdx {
+	return s.db.CurrentAccountIdx
+}
+
+// SetCurrentIdx stores Idx in the StateDB
+func (s *StateDB) SetCurrentAccountIdx(idx common.AccountIdx) error {
+	return s.db.SetCurrentAccountIdx(idx)
+}
+
+// GetMTRootAccount returns the root of the Account Merkle Tree
+func (s *StateDB) GetMTRootAccount() *big.Int {
+	return s.AccountTree.Root().BigInt()
+}
+
+// func stringToByte(s string, numByte int) []byte {
+// 	b := make([]byte, numByte)
+// 	copy(b[:], s)
+// 	return b
+// }
+
+// func BytesAccount(a *models.Account) [91]byte {
+// 	var b [91]byte
+// 	// Convert Idx into [2]byte
+// 	binary.LittleEndian.PutUint16(b[0:2], uint16(a.Idx))
+
+// 	// Convert EthAddr into [20]byte
+// 	addBytes := stringToByte(a.EthAddr, 20)
+// 	copy(b[2:22], addBytes)
+
+// 	//Unpack BJJ
+// 	// Conver pky into [32]byte and store pkSign
+// 	pkSign, pkY := babyjub.UnpackSignY([32]byte(stringToByte(a.BJJ, 32)))
+// 	if pkSign {
+// 		b[22] = 1
+// 	} else {
+// 		b[22] = 0
+// 	}
+
+// 	copy(b[23:57], pkY.Bytes())
+
+// 	// Convert balance into [24]byte
+// 	binary.LittleEndian.PutUint64(b[57:79], uint64(a.Balance))
+
+// 	// Convert score into [4]byte
+// 	binary.LittleEndian.PutUint32(b[79:83], uint32(a.Score))
+
+// 	// Convert nounce into [8]byte
+// 	binary.LittleEndian.PutUint64(b[83:91], uint64(a.Nonce))
+
+// 	return b
+// }
+
+// func AccountFromBytes(b [91]byte) models.Account {
+// 	var a models.Account
+
+// 	// Extract Idx from [0:2]
+// 	a.Idx = int(binary.LittleEndian.Uint16(b[0:2]))
+
+// 	// Extract EthAddr from [2:22]
+// 	a.EthAddr = string(b[2:22])
+
+// 	// Extract BJJ Sign and pkY from [22:57]
+// 	pkSign := b[22] == 1
+// 	pkY := new(big.Int).SetBytes(b[23:57])
+// 	bjj := babyjub.PackSignY(pkSign, pkY)
+// 	a.BJJ = string(bjj[:])
+// 	// Extract Balance from [57:79]
+// 	a.Balance = int(binary.LittleEndian.Uint64(b[57:79]))
+
+// 	// Extract Score from [79:83]
+// 	a.Score = int(binary.LittleEndian.Uint32(b[79:83]))
+
+// 	// Extract Nonce from [83:91]
+// 	a.Nonce = int(binary.LittleEndian.Uint64(b[83:91]))
+
+// 	return a
+// }
+
+// // Calculates poseidonHash for zk-Snark rollup Proof
+// func PoseidonHashAccount(a *models.Account) (*big.Int, error) {
+// 	bigInt := make([]*big.Int, 3)
+// 	b := BytesAccount(a)
+
+// 	bigInt[0] = new(big.Int).SetBytes(b[0:32])
+// 	bigInt[1] = new(big.Int).SetBytes(b[32:64])
+// 	bigInt[2] = new(big.Int).SetBytes(b[64:91])
+
+// 	return poseidon.Hash(bigInt)
+// }
+
+// // Put stores an account in the database and updates the Merkle tree.
+// func (sdb *StateDB) PutAccount(a *models.Account) (*merkletree.CircomProcessorProof, error) {
+// 	var idxBytes [2]byte
+
+// 	apHash, _ := PoseidonHashAccount(a)
+// 	fmt.Println(apHash, "---------------  Poseidon Hash Account ---------------")
+// 	accountBytes := BytesAccount(a)
+
+// 	binary.LittleEndian.PutUint16(idxBytes[:], uint16(a.Idx))
+
+// 	tx, err := sdb.db.NewTx()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	err = tx.Put(append(PrefixKeyAccHash, apHash.Bytes()...), accountBytes[:])
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	err = tx.Put(append(PrefixKeyAccountIdx, idxBytes[:]...), apHash.Bytes())
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	if err := tx.Commit(); err != nil {
+// 		return nil, err
+// 	}
+
+// 	// Update the Merkle tree and return a CircomProcessorProof if the Merkle tree is not nil
+// 	if sdb.AccountTree != nil {
+// 		return sdb.AccountTree.AddAndGetCircomProof(BigInt(a.Idx), apHash)
+// 	}
+// 	return nil, nil
+// }

--- a/sequencer/database/statedb/merkel_tree.go
+++ b/sequencer/database/statedb/merkel_tree.go
@@ -1,0 +1,21 @@
+package statedb
+
+import (
+	"math/big"
+)
+
+type enum string
+
+const (
+	Account enum = "Account"
+	Vouch   enum = "Vouch"
+	Score   enum = "Score"
+)
+
+type TreeNodeHash interface {
+}
+
+// BigInt returns a *big.Int representing the Idx
+func BigInt(idx int) *big.Int {
+	return big.NewInt(int64(idx))
+}

--- a/sequencer/database/statedb/score_service.go
+++ b/sequencer/database/statedb/score_service.go
@@ -1,0 +1,167 @@
+package statedb
+
+import (
+	"errors"
+	"math/big"
+	"tokamak-sybil-resistance/common"
+
+	"github.com/iden3/go-merkletree"
+	"github.com/iden3/go-merkletree/db"
+)
+
+var (
+	// ErrScoreAlreadyExists is used when CreateScore is called and the
+	// Score already exists
+	ErrScoreAlreadyExists = errors.New("cannot CreateScore becase Score already exists")
+	// PrefixKeyScoIdx is the key prefix for accountIdx in ScoreTree
+	PrefixKeyScoIdx = []byte("s:")
+)
+
+// CreateScore creates a new Score in the StateDB for the given Idx. If
+// StateDB.MT==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) CreateScore(idx common.AccountIdx, score *common.Score) (
+	*merkletree.CircomProcessorProof, error) {
+	cpp, err := CreateScoreInTreeDB(s.db.DB(), s.ScoreTree, idx, score)
+	if err != nil {
+		return cpp, common.Wrap(err)
+	}
+	return cpp, nil
+}
+
+// CreateScoreInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree. Creates a new Score in the StateDB for the given Idx. If
+// StateDB.MT==nil, MerkleTree is no affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof
+func CreateScoreInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.AccountIdx,
+	score *common.Score) (*merkletree.CircomProcessorProof, error) {
+	// store at the DB the key: idx, and value: leaf value
+	// tx, err := sto.NewTx()
+	// if err != nil {
+	// 	return nil, common.Wrap(err)
+	// }
+
+	// idxBytes, err := idx.Bytes()
+	// if err != nil {
+	// 	return nil, common.Wrap(err)
+	// }
+
+	// _, err = tx.Get(append(PrefixKeyScoIdx, idxBytes[:]...))
+	// if err != db.ErrNotFound {
+	// 	return nil, common.Wrap(ErrScoreAlreadyExists)
+	// }
+
+	// bytesFromScore, err := score.Bytes()
+	// if err != nil {
+	// 	return nil, common.Wrap(err)
+	// }
+
+	// err = tx.Put(append(PrefixKeyScoIdx, idxBytes[:]...), bytesFromScore[:])
+	// if err != nil {
+	// 	return nil, common.Wrap(err)
+	// }
+
+	// if err := tx.Commit(); err != nil {
+	// 	return nil, common.Wrap(err)
+	// }
+	txError := performTxScore(sto, idx, score, true)
+	if txError != nil {
+		return nil, txError
+	}
+
+	if mt != nil {
+		return mt.AddAndGetCircomProof(idx.BigInt(), score.BigInt())
+	}
+
+	return nil, nil
+}
+
+// GetScore returns the score for the given Idx
+func (s *StateDB) GetScore(idx common.AccountIdx) (*common.Score, error) {
+	return GetScoreInTreeDB(s.db.DB(), idx)
+}
+
+// GetScoreInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  GetScore returns the score for the given Idx
+func GetScoreInTreeDB(sto db.Storage, idx common.AccountIdx) (*common.Score, error) {
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	scoBytes, err := sto.Get(append(PrefixKeyScoIdx, idxBytes[:]...))
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	var b [4]byte
+	copy(b[:], scoBytes)
+	score, err := common.ScoreFromBytes(b)
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	score.Idx = idx
+	return score, nil
+}
+
+// UpdateScore updates the Score in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) UpdateScore(idx common.AccountIdx, score *common.Score) (
+	*merkletree.CircomProcessorProof, error) {
+	return UpdateScoreInTreeDB(s.db.DB(), s.ScoreTree, idx, score)
+}
+
+// UpdateScoreInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  Updates the Score in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func UpdateScoreInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.AccountIdx,
+	score *common.Score) (*merkletree.CircomProcessorProof, error) {
+	// store at the DB the key: idx and value: leaf value
+	txError := performTxScore(sto, idx, score, false)
+	if txError != nil {
+		return nil, txError
+	}
+
+	if mt != nil {
+		proof, err := mt.Update(idx.BigInt(), score.BigInt())
+		return proof, common.Wrap(err)
+	}
+	return nil, nil
+}
+
+// GetMTRoot returns the root of the Merkle Tree
+func (s *StateDB) GetMTRootScore() *big.Int {
+	return s.AccountTree.Root().BigInt()
+}
+
+func performTxScore(sto db.Storage, idx common.AccountIdx,
+	score *common.Score, addCall bool) error {
+	// store at the DB the key: idx and value: leaf value
+	tx, err := sto.NewTx()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	scoreBytes, err := score.Bytes()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	if addCall {
+		_, err = tx.Get(append(PrefixKeyScoIdx, idxBytes[:]...))
+		if err != db.ErrNotFound {
+			return common.Wrap(ErrScoreAlreadyExists)
+		}
+	}
+	err = tx.Put(append(PrefixKeyScoIdx, idxBytes[:]...), scoreBytes[:])
+	if err != nil {
+		return common.Wrap(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return common.Wrap(err)
+	}
+	return nil
+}

--- a/sequencer/database/statedb/state_db.go
+++ b/sequencer/database/statedb/state_db.go
@@ -1,0 +1,194 @@
+package statedb
+
+import (
+	"errors"
+	"tokamak-sybil-resistance/common"
+	"tokamak-sybil-resistance/database/kvdb"
+	"tokamak-sybil-resistance/log"
+
+	"github.com/iden3/go-merkletree"
+)
+
+const (
+	// TypeSynchronizer defines a StateDB used by the Synchronizer, that
+	// generates the ExitTree when processing the txs
+	TypeSynchronizer = "synchronizer"
+	// TypeTxSelector defines a StateDB used by the TxSelector, without
+	// computing ExitTree neither the ZKInputs
+	TypeTxSelector = "txselector"
+	// TypeBatchBuilder defines a StateDB used by the BatchBuilder, that
+	// generates the ExitTree and the ZKInput when processing the txs
+	TypeBatchBuilder = "batchbuilder"
+	// MaxNLevels is the maximum value of NLevels for the merkle tree,
+	// which comes from the fact that AccountIdx has 48 bits.
+	MaxNLevels = 48
+)
+
+// Config of the StateDB
+type Config struct {
+	// Path where the checkpoints will be stored
+	Path string
+	// Keep is the number of old checkpoints to keep.  If 0, all
+	// checkpoints are kept.
+	Keep int
+	// NoLast skips having an opened DB with a checkpoint to the last
+	// batchNum for thread-safe reads.
+	NoLast bool
+	// Type of StateDB (
+	Type TypeStateDB
+	// NLevels is the number of merkle tree levels in case the Type uses a
+	// merkle tree.  If the Type doesn't use a merkle tree, NLevels should
+	// be 0.
+	NLevels int
+	// At every checkpoint, check that there are no gaps between the
+	// checkpoints
+	noGapsCheck bool
+}
+
+var (
+	// ErrStateDBWithoutMT is used when a method that requires a MerkleTree
+	// is called in a StateDB that does not have a MerkleTree defined
+	ErrStateDBWithoutMT = errors.New(
+		"cannot call method to use MerkleTree in a StateDB without MerkleTree")
+	// ErrIdxNotFound is used when trying to get the Idx from EthAddr or
+	// EthAddr&ToBJJ
+	ErrIdxNotFound = errors.New("idx can not be found")
+	// ErrGetIdxNoCase is used when trying to get the Idx from EthAddr &
+	// BJJ with not compatible combination
+	ErrGetIdxNoCase = errors.New(
+		"cannot get Idx due unexpected combination of ethereum Address & BabyJubJub PublicKey")
+
+	// PrefixKeyMTAcc is the key prefix for account merkle tree in the db
+	PrefixKeyMTAcc = []byte("ma:")
+	// PrefixKeyMTVoc is the key prefix for vouch merkle tree in the db
+	PrefixKeyMTVoc = []byte("mv:")
+	// PrefixKeyMTSco is the key prefix for score merkle tree in the db
+	PrefixKeyMTSco = []byte("ms:")
+)
+
+// TypeStateDB determines the type of StateDB
+type TypeStateDB string
+
+// StateDB represents the state database with an integrated Merkle tree.
+type StateDB struct {
+	cfg         Config
+	db          *kvdb.KVDB
+	AccountTree *merkletree.MerkleTree
+	VouchTree   *merkletree.MerkleTree
+	ScoreTree   *merkletree.MerkleTree
+}
+
+// LocalStateDB represents the local StateDB which allows to make copies from
+// the synchronizer StateDB, and is used by the tx-selector and the
+// batch-builder. LocalStateDB is an in-memory storage.
+type LocalStateDB struct {
+	*StateDB
+	synchronizerStateDB *StateDB
+}
+
+// // initializeDB initializes and returns a Pebble DB instance.
+// func initializeDB(path string) (*pebble.Storage, error) {
+// 	db, err := pebble.NewPebbleStorage(path, false)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return db, nil
+// }
+
+// NewStateDB initializes a new StateDB.
+func NewStateDB(cfg Config) (*StateDB, error) {
+	var kv *kvdb.KVDB
+	var err error
+
+	kv, err = kvdb.NewKVDB(kvdb.Config{Path: cfg.Path, Keep: cfg.Keep,
+		NoGapsCheck: cfg.noGapsCheck, NoLast: cfg.NoLast})
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+
+	mtAccount, _ := merkletree.NewMerkleTree(kv.StorageWithPrefix(PrefixKeyMTAcc), 24)
+	mtVouch, _ := merkletree.NewMerkleTree(kv.StorageWithPrefix(PrefixKeyMTVoc), 24)
+	mtScore, _ := merkletree.NewMerkleTree(kv.StorageWithPrefix(PrefixKeyMTSco), 24)
+	return &StateDB{
+		cfg:         cfg,
+		db:          kv,
+		AccountTree: mtAccount,
+		VouchTree:   mtVouch,
+		ScoreTree:   mtScore,
+	}, nil
+}
+
+// Type returns the StateDB configured Type
+func (s *StateDB) Type() TypeStateDB {
+	return s.cfg.Type
+}
+
+// Close closes the StateDB.
+func (sdb *StateDB) Close() {
+	sdb.db.Close()
+}
+
+// NewLocalStateDB returns a new LocalStateDB connected to the given
+// synchronizerDB.  Checkpoints older than the value defined by `keep` will be
+// deleted.
+func NewLocalStateDB(cfg Config, synchronizerDB *StateDB) (*LocalStateDB, error) {
+	cfg.noGapsCheck = true
+	cfg.NoLast = true
+	s, err := NewStateDB(cfg)
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	return &LocalStateDB{
+		s,
+		synchronizerDB,
+	}, nil
+}
+
+// Reset resets the StateDB to the checkpoint at the given batchNum. Reset
+// does not delete the checkpoints between old current and the new current,
+// those checkpoints will remain in the storage, and eventually will be
+// deleted when MakeCheckpoint overwrites them.
+func (s *StateDB) Reset(batchNum common.BatchNum) error {
+	log.Debugw("Making StateDB Reset", "batch", batchNum, "type", s.cfg.Type)
+	if err := s.db.Reset(batchNum); err != nil {
+		return common.Wrap(err)
+	}
+	if s.AccountTree != nil {
+		// open the Account MT for the current s.db
+		accountTree, err := merkletree.NewMerkleTree(s.db.StorageWithPrefix(PrefixKeyMTAcc), s.AccountTree.MaxLevels())
+		if err != nil {
+			return common.Wrap(err)
+		}
+		s.AccountTree = accountTree
+	}
+	if s.VouchTree != nil {
+		// open the Vouch MT for the current s.db
+		vouchTree, err := merkletree.NewMerkleTree(s.db.StorageWithPrefix(PrefixKeyMTVoc), s.VouchTree.MaxLevels())
+		if err != nil {
+			return common.Wrap(err)
+		}
+		s.VouchTree = vouchTree
+	}
+	if s.ScoreTree != nil {
+		// open the Score MT for the current s.db
+		scoreTree, err := merkletree.NewMerkleTree(s.db.StorageWithPrefix(PrefixKeyMTSco), s.ScoreTree.MaxLevels())
+		if err != nil {
+			return common.Wrap(err)
+		}
+		s.ScoreTree = scoreTree
+	}
+	return nil
+}
+
+// MakeCheckpoint does a checkpoint at the given batchNum in the defined path.
+// Internally this advances & stores the current BatchNum, and then stores a
+// Checkpoint of the current state of the StateDB.
+func (s *StateDB) MakeCheckpoint() error {
+	log.Debugw("Making StateDB checkpoint", "batch", s.CurrentBatch()+1, "type", s.cfg.Type)
+	return s.db.MakeCheckpoint()
+}
+
+// CurrentBatch returns the current in-memory CurrentBatch of the StateDB.db
+func (s *StateDB) CurrentBatch() common.BatchNum {
+	return s.db.CurrentBatch
+}

--- a/sequencer/database/statedb/state_db_test.go
+++ b/sequencer/database/statedb/state_db_test.go
@@ -1,0 +1,456 @@
+package statedb
+
+import (
+	"encoding/hex"
+	"math/big"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+	"tokamak-sybil-resistance/common"
+	"tokamak-sybil-resistance/log"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/iden3/go-iden3-crypto/babyjub"
+	"github.com/iden3/go-merkletree/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var deleteme []string
+
+func init() {
+	log.Init("debug", []string{"stdout"})
+}
+func TestMain(m *testing.M) {
+	exitVal := 0
+	exitVal = m.Run()
+	for _, dir := range deleteme {
+		if err := os.RemoveAll(dir); err != nil {
+			panic(err)
+		}
+	}
+	os.Exit(exitVal)
+}
+
+func newAccount(t *testing.T, i int) *common.Account {
+	var sk babyjub.PrivateKey
+	_, err := hex.Decode(sk[:],
+		[]byte("0001020304050607080900010203040506070809000102030405060708090001"))
+	require.NoError(t, err)
+	pk := sk.Public()
+
+	key, err := ethCrypto.GenerateKey()
+	require.NoError(t, err)
+	address := ethCrypto.PubkeyToAddress(key.PublicKey)
+
+	return &common.Account{
+		Idx:     common.AccountIdx(256 + i),
+		Nonce:   common.Nonce(i),
+		Balance: big.NewInt(1000),
+		BJJ:     pk.Compress(),
+		EthAddr: address,
+	}
+}
+
+func newVouch(i int) *common.Vouch {
+	r := rand.New(rand.NewSource(int64(time.Now().UnixNano())))
+	v := r.Intn(2) == 1
+	return &common.Vouch{
+		Idx:   common.VouchIdx(256257 + i),
+		Value: v,
+	}
+}
+
+func newScore(i int) *common.Score {
+	return &common.Score{
+		Idx:   common.AccountIdx(256 + i),
+		Value: uint32(1 + i),
+	}
+}
+
+func TestAccountInStateDB(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tmpdb")
+	require.NoError(t, err)
+	deleteme = append(deleteme, dir)
+
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 0})
+	require.NoError(t, err)
+
+	// create test accounts
+	var accounts []*common.Account
+	for i := 0; i < 4; i++ {
+		accounts = append(accounts, newAccount(t, i))
+	}
+
+	// get non-existing account, expecting an error
+	unexistingAccount := common.AccountIdx(1)
+	_, err = sdb.GetAccount(unexistingAccount)
+	assert.NotNil(t, err)
+	assert.Equal(t, db.ErrNotFound, common.Unwrap(err))
+
+	// add test accounts
+	for i := 0; i < len(accounts); i++ {
+		_, err = sdb.CreateAccount(accounts[i].Idx, accounts[i])
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < len(accounts); i++ {
+		existingAccount := accounts[i].Idx
+		accGetted, err := sdb.GetAccount(existingAccount)
+		require.NoError(t, err)
+		assert.Equal(t, accounts[i], accGetted)
+	}
+
+	// try already existing idx and get error
+	existingAccount := common.AccountIdx(256)
+	_, err = sdb.GetAccount(existingAccount) // check that exist
+	require.NoError(t, err)
+	_, err = sdb.CreateAccount(common.AccountIdx(256), accounts[1]) // check that can not be created twice
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrAccountAlreadyExists, common.Unwrap(err))
+
+	_, err = sdb.MTGetAccountProof(common.AccountIdx(256))
+	require.NoError(t, err)
+
+	// update accounts
+	for i := 0; i < len(accounts); i++ {
+		accounts[i].Nonce = accounts[i].Nonce + 1
+		existingAccount = accounts[i].Idx
+		_, err = sdb.UpdateAccount(existingAccount, accounts[i])
+		require.NoError(t, err)
+	}
+
+	sdb.Close()
+}
+
+func TestVouchInStateDB(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tmpdb")
+	require.NoError(t, err)
+	deleteme = append(deleteme, dir)
+
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
+	require.NoError(t, err)
+
+	// create test vouches
+	var vouches []*common.Vouch
+	for i := 0; i < 4; i++ {
+		vouches = append(vouches, newVouch(i))
+	}
+
+	// get non-existing vouch, expecting an error
+	unexistingVouch := common.VouchIdx(001001)
+	_, err = sdb.GetVouch(unexistingVouch)
+	assert.NotNil(t, err)
+	assert.Equal(t, db.ErrNotFound, common.Unwrap(err))
+
+	// add test vouches
+	for i := 0; i < len(vouches); i++ {
+		_, err = sdb.CreateVouch(vouches[i].Idx, vouches[i])
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < len(vouches); i++ {
+		existingVouch := vouches[i].Idx
+		vocGetted, err := sdb.GetVouch(existingVouch)
+		require.NoError(t, err)
+		assert.Equal(t, vouches[i], vocGetted)
+	}
+
+	// try already existing idx and get error
+	existingVouch := common.VouchIdx(256257)
+	_, err = sdb.GetVouch(existingVouch) // check that exist
+	require.NoError(t, err)
+	_, err = sdb.CreateVouch(common.VouchIdx(256257), vouches[1]) // check that can not be created twice
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrAlreadyVouched, common.Unwrap(err))
+
+	_, err = sdb.MTGetVouchProof(common.VouchIdx(256257))
+	require.NoError(t, err)
+
+	// update vouches
+	for i := 0; i < len(vouches); i++ {
+		vouches[i].Value = !vouches[i].Value
+		existingVouch = vouches[i].Idx
+		_, err = sdb.UpdateVouch(existingVouch, vouches[i])
+		require.NoError(t, err)
+	}
+
+	sdb.Close()
+}
+
+func TestScoreInStateDB(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tmpdb")
+	require.NoError(t, err)
+	deleteme = append(deleteme, dir)
+
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
+	require.NoError(t, err)
+
+	// create test scores
+	var scores []*common.Score
+	for i := 0; i < 4; i++ {
+		scores = append(scores, newScore(i))
+	}
+
+	// get non-existing score, expecting an error
+	unexistingScore := common.AccountIdx(1)
+	_, err = sdb.GetScore(unexistingScore)
+	assert.NotNil(t, err)
+	assert.Equal(t, db.ErrNotFound, common.Unwrap(err))
+
+	// add test scores
+	for i := 0; i < len(scores); i++ {
+		_, err = sdb.CreateScore(scores[i].Idx, scores[i])
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < len(scores); i++ {
+		existingScore := scores[i].Idx
+		scoGetted, err := sdb.GetScore(existingScore)
+		require.NoError(t, err)
+		assert.Equal(t, scores[i], scoGetted)
+	}
+
+	// try already existing idx and get error
+	existingScore := common.AccountIdx(257)
+	_, err = sdb.GetScore(existingScore) // check that exist
+	require.NoError(t, err)
+	_, err = sdb.CreateScore(common.AccountIdx(257), scores[1]) // check that can not be created twice
+	assert.NotNil(t, err)
+	assert.Equal(t, ErrScoreAlreadyExists, common.Unwrap(err))
+
+	_, err = sdb.MTGetAccountProof(common.AccountIdx(257))
+	require.NoError(t, err)
+
+	// update scores
+	for i := 0; i < len(scores); i++ {
+		existingScore = scores[i].Idx
+		_, err = sdb.UpdateScore(existingScore, scores[i])
+		require.NoError(t, err)
+	}
+
+	sdb.Close()
+}
+
+func bigFromStr(h string, u int) *big.Int {
+	if u == 16 {
+		h = strings.TrimPrefix(h, "0x")
+	}
+	b, ok := new(big.Int).SetString(h, u)
+	if !ok {
+		panic("bigFromStr err")
+	}
+	return b
+}
+
+func TestCheckAccountsTreeTestVectors(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tmpdb")
+	require.NoError(t, err)
+	deleteme = append(deleteme, dir)
+
+	sdb, err := NewStateDB(Config{Path: dir, Keep: 128, Type: TypeSynchronizer, NLevels: 32})
+	require.NoError(t, err)
+
+	ay0 := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(253), nil), big.NewInt(1))
+	// test value from js version (compatibility-canary)
+	assert.Equal(t, "1fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		(hex.EncodeToString(ay0.Bytes())))
+	bjjPoint0Comp := babyjub.PackSignY(true, ay0)
+	bjj0 := babyjub.PublicKeyComp(bjjPoint0Comp)
+
+	ay1 := bigFromStr("00", 16)
+	bjjPoint1Comp := babyjub.PackSignY(false, ay1)
+	bjj1 := babyjub.PublicKeyComp(bjjPoint1Comp)
+	ay2 := bigFromStr("21b0a1688b37f77b1d1d5539ec3b826db5ac78b2513f574a04c50a7d4f8246d7", 16)
+	bjjPoint2Comp := babyjub.PackSignY(false, ay2)
+	bjj2 := babyjub.PublicKeyComp(bjjPoint2Comp)
+
+	ay3 := bigFromStr("0x10", 16) // 0x10=16
+	bjjPoint3Comp := babyjub.PackSignY(false, ay3)
+	require.NoError(t, err)
+	bjj3 := babyjub.PublicKeyComp(bjjPoint3Comp)
+	accounts := []*common.Account{
+		{
+			Idx:     1,
+			BJJ:     bjj0,
+			EthAddr: ethCommon.HexToAddress("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+			Nonce:   common.Nonce(0xFFFFFFFFFF),
+			Balance: bigFromStr("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16),
+		},
+		{
+			Idx:     100,
+			BJJ:     bjj1,
+			EthAddr: ethCommon.HexToAddress("0x00"),
+			Nonce:   common.Nonce(0),
+			Balance: bigFromStr("0", 10),
+		},
+		{
+			Idx:     0xFFFFFF,
+			BJJ:     bjj2,
+			EthAddr: ethCommon.HexToAddress("0xA3C88ac39A76789437AED31B9608da72e1bbfBF9"),
+			Nonce:   common.Nonce(129),
+			Balance: bigFromStr("42000000000000000000", 10),
+		},
+		{
+			Idx:     10000,
+			BJJ:     bjj3,
+			EthAddr: ethCommon.HexToAddress("0x64"),
+			Nonce:   common.Nonce(1900),
+			Balance: bigFromStr("14000000000000000000", 10),
+		},
+	}
+	for i := 0; i < len(accounts); i++ {
+		_, err = accounts[i].HashValue()
+		require.NoError(t, err)
+		_, err = sdb.CreateAccount(accounts[i].Idx, accounts[i])
+		if err != nil {
+			log.Error(err)
+		}
+		require.NoError(t, err)
+	}
+	// root value generated by js version:
+	assert.Equal(t,
+		"6042732623065908215915192128670856333144563413308193635978934416138840158630",
+		sdb.AccountTree.Root().BigInt().String())
+
+	sdb.Close()
+}
+
+// // performActions function for Account and Link are to test the db setup and
+// // it's mapping with merkel tree
+// func performActionsAccount(a *models.Account, s *StateDB) {
+// 	proof, err := s.PutAccount(a)
+// 	if err != nil {
+// 		log.Fatalf("Failed to store key-value pair: %v", err)
+// 	}
+// 	fmt.Println(proof, "----------------------- Circom Processor Proof ---------------------")
+
+// 	// Retrieve and print a value
+// 	value, err := s.GetAccount(a.Idx)
+// 	if err != nil {
+// 		log.Fatalf("Failed to retrieve value: %v", err)
+// 	}
+// 	fmt.Printf("Retrieved account: %+v\n", value)
+
+// 	// Get and print root hash for leaf
+// 	root := s.GetMTRoot(Account)
+// 	fmt.Println(root, "MT root")
+// }
+
+// func performActionsLink(l *models.Link, s *StateDB) {
+// 	proof, err := s.PutLink(l)
+// 	if err != nil {
+// 		log.Fatalf("Failed to store key-value pair: %v", err)
+// 	}
+// 	fmt.Println(proof, "----------------------- Circom Processor Proof ---------------------")
+// 	// Retrieve and print a value
+// 	value, err := s.GetLink(l.LinkIdx)
+// 	if err != nil {
+// 		log.Fatalf("Failed to retrieve value: %v", err)
+// 	}
+// 	fmt.Printf("Retrieved account: %+v\n", value)
+
+// 	// Get and print root hash for leaf
+// 	root := s.GetMTRoot(Link)
+// 	fmt.Println(root, "MT root")
+// }
+
+// func printExamples(s *StateDB) {
+// 	// Example accounts
+// 	accountA := &models.Account{
+// 		Idx:     1,
+// 		EthAddr: "0xA",
+// 		BJJ:     "ay_value",
+// 		Balance: 10,
+// 		Score:   1,
+// 		Nonce:   0,
+// 	}
+
+// 	accountB := &models.Account{
+// 		Idx:     2,
+// 		EthAddr: "0xB",
+// 		BJJ:     "ay_value",
+// 		Balance: 10,
+// 		Score:   1,
+// 		Nonce:   0,
+// 	}
+
+// 	accountC := &models.Account{
+// 		Idx:     3,
+// 		EthAddr: "0xC",
+// 		BJJ:     "ay_value",
+// 		Balance: 10,
+// 		Score:   1,
+// 		Nonce:   0,
+// 	}
+
+// 	accountD := &models.Account{
+// 		Idx:     4,
+// 		EthAddr: "0xD",
+// 		BJJ:     "ay_value",
+// 		Balance: 10,
+// 		Score:   1,
+// 		Nonce:   0,
+// 	}
+
+// 	linkAB := &models.Link{
+// 		LinkIdx: 11,
+// 		Value:   true,
+// 	}
+
+// 	linkAC := &models.Link{
+// 		LinkIdx: 13,
+// 		Value:   true,
+// 	}
+// 	linkCD := &models.Link{
+// 		LinkIdx: 34,
+// 		Value:   true,
+// 	}
+// 	linkCA := &models.Link{
+// 		LinkIdx: 31,
+// 		Value:   true,
+// 	}
+// 	linkCB := &models.Link{
+// 		LinkIdx: 32,
+// 		Value:   true,
+// 	}
+// 	// Add Account A
+// 	performActionsAccount(accountA, s)
+
+// 	// Add Account B
+// 	performActionsAccount(accountB, s)
+
+// 	//Add Account C
+// 	performActionsAccount(accountC, s)
+
+// 	//Add Account D
+// 	performActionsAccount(accountD, s)
+
+// 	//Add Link AB
+// 	performActionsLink(linkAB, s)
+
+// 	performActionsLink(linkAC, s)
+// 	performActionsLink(linkCD, s)
+// 	performActionsLink(linkCA, s)
+// 	performActionsLink(linkCB, s)
+
+// 	// Print Merkle tree root
+// 	// fmt.Printf("Merkle Account Tree Root: %s\n", s.AccountTree.Root.Hash)
+// }
+
+// func TestInitNewStateDB(t *testing.T) {
+// 	dir, err := ioutil.TempDir("", "tmpdb")
+
+// 	// Initialize the StateDB
+// 	var stateDB *StateDB
+// 	stateDB, err = NewStateDB(Config{Path: dir, Keep: 128, Type: TypeTxSelector, NLevels: 0})
+// 	if err != nil {
+// 		log.Fatalf("Failed to initialize StateDB: %v", err)
+// 	}
+// 	defer stateDB.Close()
+// 	printExamples(stateDB)
+// }

--- a/sequencer/database/statedb/utils.go
+++ b/sequencer/database/statedb/utils.go
@@ -1,0 +1,134 @@
+package statedb
+
+import (
+	"bytes"
+	"fmt"
+	"tokamak-sybil-resistance/common"
+	"tokamak-sybil-resistance/log"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/iden3/go-iden3-crypto/babyjub"
+	"github.com/iden3/go-merkletree/db"
+)
+
+func concatEthAddr(addr ethCommon.Address) []byte {
+	var b []byte
+	b = append(b, addr.Bytes()...)
+	return b
+}
+func concatEthAddrBJJ(addr ethCommon.Address, pk babyjub.PublicKeyComp) []byte {
+	pkComp := pk
+	var b []byte
+	b = append(b, addr.Bytes()...)
+	b = append(b[:], pkComp[:]...)
+	return b
+}
+
+// GetIdxByEthAddr returns the smallest Idx in the StateDB for the given
+// Ethereum Address. Will return common.Idx(0) and error in case that Idx is
+// not found in the StateDB.
+func (s *StateDB) GetIdxByEthAddr(addr ethCommon.Address) (common.AccountIdx,
+	error) {
+	k := concatEthAddr(addr)
+	b, err := s.db.DB().Get(append(PrefixKeyAddr, k...))
+	if err != nil {
+		return common.AccountIdx(0), common.Wrap(fmt.Errorf("GetIdxByEthAddr: %s: ToEthAddr: %s",
+			ErrIdxNotFound, addr.Hex()))
+	}
+	idx, err := common.AccountIdxFromBytes(b)
+	if err != nil {
+		return common.AccountIdx(0), common.Wrap(fmt.Errorf("GetIdxByEthAddr: %s: ToEthAddr: %s",
+			err, addr.Hex()))
+	}
+	return idx, nil
+}
+
+// GetIdxByEthAddrBJJ returns the smallest Idx in the StateDB for the given
+// Ethereum Address AND the given BabyJubJub PublicKey. If `addr` is the zero
+// address, it's ignored in the query.  If `pk` is nil, it's ignored in the
+// query.  Will return common.Idx(0) and error in case that Idx is not found in
+// the StateDB.
+func (s *StateDB) GetIdxByEthAddrBJJ(addr ethCommon.Address, pk babyjub.PublicKeyComp) (common.AccountIdx, error) {
+	if !bytes.Equal(addr.Bytes(), common.EmptyAddr.Bytes()) && pk == common.EmptyBJJComp {
+		// ToEthAddr
+		// case ToEthAddr!=0 && ToBJJ=0
+		return s.GetIdxByEthAddr(addr)
+	} else if !bytes.Equal(addr.Bytes(), common.EmptyAddr.Bytes()) &&
+		pk != common.EmptyBJJComp {
+		// case ToEthAddr!=0 && ToBJJ!=0
+		k := concatEthAddrBJJ(addr, pk)
+		b, err := s.db.DB().Get(append(PrefixKeyAddrBJJ, k...))
+		if common.Unwrap(err) == db.ErrNotFound {
+			// return the error (ErrNotFound), so can be traced at upper layers
+			return common.AccountIdx(0), common.Wrap(ErrIdxNotFound)
+		} else if err != nil {
+			return common.AccountIdx(0),
+				common.Wrap(fmt.Errorf("GetIdxByEthAddrBJJ: %s: ToEthAddr: %s, ToBJJ: %s",
+					ErrIdxNotFound, addr.Hex(), pk))
+		}
+		idx, err := common.AccountIdxFromBytes(b)
+		if err != nil {
+			return common.AccountIdx(0),
+				common.Wrap(fmt.Errorf("GetIdxByEthAddrBJJ: %s: ToEthAddr: %s, ToBJJ: %s",
+					err, addr.Hex(), pk))
+		}
+		return idx, nil
+	}
+	// rest of cases (included case ToEthAddr==0) are not possible
+	return common.AccountIdx(0),
+		common.Wrap(
+			fmt.Errorf("GetIdxByEthAddrBJJ: Not found, %s: ToEthAddr: %s, ToBJJ: %s",
+				ErrGetIdxNoCase, addr.Hex(), pk))
+}
+
+// setIdxByEthAddrBJJ stores the given Idx in the StateDB as follows:
+// - key: Eth Address, value: idx
+// - key: EthAddr & BabyJubJub PublicKey Compressed, value: idx
+// If Idx already exist for the given EthAddr & BJJ, the remaining Idx will be
+// always the smallest one.
+func (s *StateDB) setIdxByEthAddrBJJ(idx common.AccountIdx, addr ethCommon.Address,
+	pk babyjub.PublicKeyComp) error {
+	oldIdx, err := s.GetIdxByEthAddrBJJ(addr, pk)
+	if err == nil {
+		// EthAddr & BJJ already have an Idx
+		// check which Idx is smaller
+		// if new idx is smaller, store the new one
+		// if new idx is bigger, don't store and return, as the used one will be the old
+		if idx >= oldIdx {
+			log.Debug("StateDB.setIdxByEthAddrBJJ: Idx not stored because there " +
+				"already exist a smaller Idx for the given EthAddr & BJJ")
+			return nil
+		}
+	}
+
+	// store idx for EthAddr & BJJ assuming that EthAddr & BJJ still don't
+	// have an Idx stored in the DB, and if so, the already stored Idx is
+	// bigger than the given one, so should be updated to the new one
+	// (smaller)
+	tx, err := s.db.DB().NewTx()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	// store Addr&BJJ-idx
+	k := concatEthAddrBJJ(addr, pk)
+	err = tx.Put(append(PrefixKeyAddrBJJ, k...), idxBytes[:])
+	if err != nil {
+		return common.Wrap(err)
+	}
+
+	// store Addr-idx
+	k = concatEthAddr(addr)
+	err = tx.Put(append(PrefixKeyAddr, k...), idxBytes[:])
+	if err != nil {
+		return common.Wrap(err)
+	}
+	err = tx.Commit()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	return nil
+}

--- a/sequencer/database/statedb/vouch_service.go
+++ b/sequencer/database/statedb/vouch_service.go
@@ -1,0 +1,230 @@
+package statedb
+
+import (
+	"errors"
+	"math/big"
+	"tokamak-sybil-resistance/common"
+
+	"github.com/iden3/go-merkletree"
+	"github.com/iden3/go-merkletree/db"
+)
+
+var (
+	ErrAlreadyVouched = errors.New("can not Vouch because already vouched")
+	// PrefixKeyVocIdx is the key prefix for vouchIdx in the db
+	PrefixKeyVocIdx = []byte("v:")
+)
+
+// CreateVouch creates a new Vouch in the StateDB for the given Idx. If
+// StateDB.MT==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) CreateVouch(idx common.VouchIdx, vouch *common.Vouch) (
+	*merkletree.CircomProcessorProof, error) {
+	cpp, err := CreateVouchInTreeDB(s.db.DB(), s.VouchTree, idx, vouch)
+	if err != nil {
+		return cpp, common.Wrap(err)
+	}
+	return cpp, nil
+}
+
+// CreateVouchInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree. Creates a new Vouch in the StateDB for the given Idx. If
+// StateDB.MT==nil, MerkleTree is no affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof
+func CreateVouchInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.VouchIdx,
+	vouch *common.Vouch) (*merkletree.CircomProcessorProof, error) {
+	txError := performTxVouch(sto, idx, vouch, true)
+	if txError != nil {
+		return nil, txError
+	}
+
+	if mt != nil {
+		return mt.AddAndGetCircomProof(idx.BigInt(), common.BigIntFromBool(vouch.Value))
+	}
+
+	return nil, nil
+}
+
+// MTGetVouchProof returns the CircomVerifierProof for a given vouchIdx
+func (s *StateDB) MTGetVouchProof(idx common.VouchIdx) (*merkletree.CircomVerifierProof, error) {
+	if s.VouchTree == nil {
+		return nil, common.Wrap(ErrStateDBWithoutMT)
+	}
+	p, err := s.VouchTree.GenerateSCVerifierProof(idx.BigInt(), s.VouchTree.Root())
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	return p, nil
+}
+
+// GetVouch returns the vouch for the given Idx
+func (s *StateDB) GetVouch(idx common.VouchIdx) (*common.Vouch, error) {
+	return GetVouchInTreeDB(s.db.DB(), idx)
+}
+
+// GetVouchInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  GetVouch returns the vouch for the given Idx
+func GetVouchInTreeDB(sto db.Storage, idx common.VouchIdx) (*common.Vouch, error) {
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	vocBytes, err := sto.Get(append(PrefixKeyVocIdx, idxBytes[:]...))
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	var b [1]byte
+	copy(b[:], vocBytes)
+	vouch, err := common.VouchFromBytes(b)
+	if err != nil {
+		return nil, common.Wrap(err)
+	}
+	vouch.Idx = idx
+	return vouch, nil
+}
+
+// UpdateVouch updates the Vouch in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func (s *StateDB) UpdateVouch(idx common.VouchIdx, vouch *common.Vouch) (
+	*merkletree.CircomProcessorProof, error) {
+	return UpdateVouchInTreeDB(s.db.DB(), s.VouchTree, idx, vouch)
+}
+
+// UpdateVouchInTreeDB is abstracted from StateDB to be used from StateDB and
+// from ExitTree.  Updates the Vouch in the StateDB for the given Idx.  If
+// StateDB.mt==nil, MerkleTree is not affected, otherwise updates the
+// MerkleTree, returning a CircomProcessorProof.
+func UpdateVouchInTreeDB(sto db.Storage, mt *merkletree.MerkleTree, idx common.VouchIdx,
+	vouch *common.Vouch) (*merkletree.CircomProcessorProof, error) {
+	txError := performTxVouch(sto, idx, vouch, false)
+	if txError != nil {
+		return nil, txError
+	}
+
+	if mt != nil {
+		proof, err := mt.Update(idx.BigInt(), common.BigIntFromBool(vouch.Value))
+		return proof, common.Wrap(err)
+	}
+	return nil, nil
+}
+
+// GetMTRoot returns the root of the Merkle Tree
+func (s *StateDB) GetMTRootVouch() *big.Int {
+	return s.AccountTree.Root().BigInt()
+}
+
+func performTxVouch(sto db.Storage, idx common.VouchIdx,
+	vouch *common.Vouch, addCall bool) error {
+	tx, err := sto.NewTx()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	idxBytes, err := idx.Bytes()
+	if err != nil {
+		return common.Wrap(err)
+	}
+	if addCall {
+		_, err = tx.Get(append(PrefixKeyVocIdx, idxBytes[:]...))
+		if err != db.ErrNotFound {
+			return common.Wrap(ErrAlreadyVouched)
+		}
+	}
+	err = tx.Put(append(PrefixKeyVocIdx, idxBytes[:]...), vouch.BytesFromBool())
+	if err != nil {
+		return common.Wrap(err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return common.Wrap(err)
+	}
+	return nil
+}
+
+// func BytesLink(l *models.Link) [5]byte {
+// 	var b [5]byte
+
+// 	// Convert linkIdx into [4]byte
+// 	binary.LittleEndian.PutUint32(b[0:4], uint32(l.LinkIdx))
+
+// 	if l.Value {
+// 		b[4] = 1
+// 	} else {
+// 		b[4] = 0
+// 	}
+
+// 	return b
+// }
+
+// func LinkFromBytes(b [5]byte) models.Link {
+// 	var l models.Link
+
+// 	// Extract Idx from [0:4]
+// 	l.LinkIdx = int(binary.LittleEndian.Uint32(b[0:4]))
+
+// 	l.Value = b[4] == 1
+
+// 	return l
+// }
+
+// // Calculates poseidonHash for zk-Snark rollup Proof
+// func PoseidonHashLink(l *models.Link) (*big.Int, error) {
+// 	bigInt := make([]*big.Int, 3)
+
+// 	b := BytesLink(l)
+
+// 	bigInt[0] = new(big.Int).SetBytes(b[0:2])
+// 	bigInt[1] = new(big.Int).SetBytes(b[2:4])
+// 	bigInt[2] = new(big.Int).SetBytes(b[4:4])
+
+// 	return poseidon.Hash(bigInt)
+// }
+
+// // PutLink stores a link in the database and updates the Link Merkle tree.
+// func (sdb *StateDB) PutLink(l *models.Link) (*merkletree.CircomProcessorProof, error) {
+// 	var idxBytes [4]byte
+// 	linkBytes := BytesLink(l)
+// 	binary.LittleEndian.PutUint32(idxBytes[:], uint32(l.LinkIdx))
+// 	linkHash, _ := PoseidonHashLink(l)
+// 	fmt.Println(linkHash, "---------------  Poseidon Hash Account ---------------")
+
+// 	tx, err := sdb.db.NewTx()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	err = tx.Put(append(PrefixKeyLinkHash, linkHash.Bytes()...), linkBytes[:])
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	err = tx.Put(append(PrefixKeyLinkIdx, idxBytes[:]...), linkHash.Bytes())
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	if err := tx.Commit(); err != nil {
+// 		return nil, err
+// 	}
+// 	return sdb.LinkTree.AddAndGetCircomProof(BigInt(l.LinkIdx), linkHash)
+// }
+
+// // GetLink retrieves a link for a given linkIdx from the database.
+// func (sdb *StateDB) GetLink(linkIdx int) (*models.Link, error) {
+// 	var linkIdxBytes [4]byte
+// 	// Convert Idx into [2]byte
+// 	binary.LittleEndian.PutUint32(linkIdxBytes[0:4], uint32(linkIdx))
+
+// 	linkHashBytes, err := sdb.db.Get(append(PrefixKeyLinkIdx, linkIdxBytes[:]...))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	linkBytes, err := sdb.db.Get(append(PrefixKeyLinkHash, linkHashBytes...))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	link := LinkFromBytes([5]byte(linkBytes))
+
+// 	return &link, nil
+// }


### PR DESCRIPTION
`statedb` directory got deleted when `go_sequencer` was renamed as `sequencer` because `statedb` for some reason in `.gitignore`. This PR removed `statedb` from `.gitignore` and restores all `statedb` files in `develop`.

[relevant discussion link](https://tokamak-network.slack.com/archives/C074PEUC2CR/p1731385180019689?thread_ts=1731368792.806749&cid=C074PEUC2CR)