### PR TITLE
fix/add applyVouch func to update nonce, re-add amount into L2Tx and …

### DIFF
--- a/sequencer/synchronizer/synchronizer_test.go
+++ b/sequencer/synchronizer/synchronizer_test.go
@@ -360,6 +360,8 @@ func TestSyncGeneral(t *testing.T) {
 		ForceExit B: 80
 
 		CreateVouch C-A
+		CreateVouch C-B
+		CreateVouch C-D
 		Exit C: 50
 		Exit D: 30
 
@@ -393,7 +395,7 @@ func TestSyncGeneral(t *testing.T) {
 	require.Equal(t, 3, int(blocks[i].Block.Num))
 	require.Equal(t, 2, len(blocks[i].Rollup.L1UserTxs))
 	require.Equal(t, 2, len(blocks[i].Rollup.Batches))
-	require.Equal(t, 3, len(blocks[i].Rollup.Batches[0].L2Txs))
+	require.Equal(t, 5, len(blocks[i].Rollup.Batches[0].L2Txs))
 	// Set StateRoots for batches manually (til doesn't set it)
 	blocks[i].Rollup.Batches[0].Batch.StateRoot =
 		newBigInt("13535760140937349829640752733057594576151546047374619177689224612061148090678")

--- a/sequencer/test/til/txs.go
+++ b/sequencer/test/til/txs.go
@@ -229,7 +229,7 @@ func (tc *Context) generateBlocks() ([]common.BlockData, error) {
 			}
 		case common.TxTypeCreateVouch:
 			tx := common.L2Tx{
-				// Amount:      inst.Amount,
+				Amount: big.NewInt(0),
 				// Fee:         common.FeeSelector(inst.Fee),
 				Type:        common.TxTypeCreateVouch,
 				EthBlockNum: tc.blockNum,
@@ -245,7 +245,7 @@ func (tc *Context) generateBlocks() ([]common.BlockData, error) {
 			tc.currBatchTest.l2Txs = append(tc.currBatchTest.l2Txs, testTx)
 		case common.TxTypeDeleteVouch:
 			tx := common.L2Tx{
-				// Amount:      inst.Amount,
+				Amount: big.NewInt(0),
 				// Fee:         common.FeeSelector(inst.Fee),
 				Type:        common.TxTypeDeleteVouch,
 				EthBlockNum: tc.blockNum,
@@ -870,7 +870,7 @@ func (tc *Context) FillBlocksExtra(blocks []common.BlockData, cfg *ConfigExtra) 
 					batch.ExitTree = append(batch.ExitTree, common.ExitInfo{
 						BatchNum:   batch.Batch.BatchNum,
 						AccountIdx: tx.FromIdx,
-						// Balance:    tx.Amount,
+						Balance:    tx.Amount,
 					})
 				}
 				// fee, err := common.CalcFeeAmount(tx.Amount, tx.Fee)

--- a/sequencer/txprocessor/txprocessor.go
+++ b/sequencer/txprocessor/txprocessor.go
@@ -898,7 +898,6 @@ func (txProcessor *TxProcessor) computeEffectiveAmounts(tx *common.L1Tx) {
 	}
 	cmp := bal.Cmp(tx.Amount)
 	if cmp == -1 {
-		panic(accSender.Idx)
 		log.Debugf("EffectiveAmount = 0: Not enough funds (%s<%s)", bal.String(), tx.Amount.String())
 		tx.EffectiveAmount = big.NewInt(0)
 		return


### PR DESCRIPTION
This PR is involving as follows:

- **ApplyVouch**
  - initially implemented nonce update logic
  - TODO: update score and link logic
- Re-add **amount** into L2Tx, and balance into ExitInfo
  > In L2Tx, there are main 4 types, including Create&DeleteVouch, Exit, Explode.
    Create&DeleteVouch don't need amount, but Exit&Explode need amount field.
    Alternatively, we can set the amount of L2Tx as 0 in the case of Create&DeleteVouch.